### PR TITLE
added option for discord ping on check-in error

### DIFF
--- a/src/main-discord.gs
+++ b/src/main-discord.gs
@@ -6,7 +6,12 @@ const profiles = [
     accountName: "YOUR NICKNAME" }
 ];
 
-const discord_notify = true
+const discord_notify = {
+  // ping on every run
+  on_run: true,
+  // ping whenever there is an unsuccessful check-in
+  on_error: false
+}
 const myDiscordID = ""
 const discordWebhook = ""
 
@@ -22,18 +27,16 @@ const urlDict = {
 async function main() {
 
   const messages = await Promise.all(profiles.map(autoSignFunction));
-  const hoyolabResp = `${discordPing()}${messages.join('\n\n')}`
+  const hoyolabResp = `${discordPing(discord_notify.on_run)}${messages.join('\n\n')}`
 
-  if(discord_notify == true) {
-    if(discordWebhook) {
-      postWebhook(hoyolabResp);
-    }
+  if(discordWebhook) {
+    postWebhook(hoyolabResp);
   }
-
+  
 }
 
-function discordPing() {
-  if(discord_notify && myDiscordID) {
+function discordPing(pingWanted) {
+  if(pingWanted && myDiscordID) {
     return `<@${myDiscordID}>\n`;
   } else {
     return '';
@@ -65,7 +68,8 @@ function autoSignFunction({ token, genshin, honkai_star_rail, honkai_3, accountN
   for (const [i, hoyolabResponse] of httpResponses.entries()) {
     const checkInResult = JSON.parse(hoyolabResponse).message;
     const gameName = Object.keys(urlDict).find(key => urlDict[key] === urls[i])?.replace(/_/g, ' ');
-    response += `\n${gameName}: ${checkInResult}`;
+    const isError = checkInResult != "OK";
+    response += `\n${gameName}: ${isError ? discordPing(discord_notify.on_error) : ""}${checkInResult}`;
   };
 
   return response;

--- a/src/main-discord_zh-tw.gs
+++ b/src/main-discord_zh-tw.gs
@@ -6,7 +6,10 @@ const profiles = [
     accountName: "你的名子" }
 ];
 
-const discord_notify = true
+const discord_notify = {
+  on_run: true,
+  on_error: false
+}
 const myDiscordID = ""
 const discordWebhook = ""
 
@@ -22,18 +25,16 @@ const urlDict = {
 async function main() {
 
   const messages = await Promise.all(profiles.map(autoSignFunction));
-  const hoyolabResp = `${discordPing()}${messages.join('\n\n')}`
+  const hoyolabResp = `${discordPing(discord_notify.on_run)}${messages.join('\n\n')}`
 
-  if(discord_notify == true) {
-    if(discordWebhook) {
-      postWebhook(hoyolabResp);
-    }
+  if(discordWebhook) {
+    postWebhook(hoyolabResp);
   }
 
 }
 
-function discordPing() {
-  if(discord_notify && myDiscordID) {
+function discordPing(pingWanted) {
+  if(pingWanted && myDiscordID) {
     return `<@${myDiscordID}>\n`;
   } else {
     return '';
@@ -76,7 +77,8 @@ function autoSignFunction({ token, genshin, honkai_star_rail, honkai_3, accountN
       gameName = '崩壞3rd';
       break;
     }
-    response += `\n${gameName}： ${checkInResult}`;
+    const isError = checkInResult != "OK";
+    response += `\n${gameName}: ${isError ? discordPing(discord_notify.on_error) : ""}${checkInResult}`;
   };
 
   return response;


### PR DESCRIPTION
started to get annoyed by the daily ping, so I made an option where it only pings when there is an error in the check-in process.

also removed the check for if discord_notify is true before calling the webhook because it became confusing with this addition and it was already checking whether discordWebhook had a value. I think its safe to assume that if someone enters a webhook URL they probably want the webhook message to be posted.