### PR TITLE
Shorten checkInResult for english language

### DIFF
--- a/src/main-discord.gs
+++ b/src/main-discord.gs
@@ -66,7 +66,7 @@ function autoSignFunction({ token, genshin, honkai_star_rail, honkai_3, accountN
   const httpResponses = UrlFetchApp.fetchAll(urls.map(url => ({ url, ...options })));
 
   for (const [i, hoyolabResponse] of httpResponses.entries()) {
-    const checkInResult = JSON.parse(hoyolabResponse).message;
+    const checkInResult = (JSON.parse(hoyolabResponse).message).match(/^[^.~]+[.~]?/)?.[0] || checkInResult;
     const gameName = Object.keys(urlDict).find(key => urlDict[key] === urls[i])?.replace(/_/g, ' ');
     const isError = checkInResult != "OK";
     response += `\n${gameName}: ${isError ? discordPing(discord_notify.on_error) : ""}${checkInResult}`;


### PR DESCRIPTION
Discord webhooks have a 2000 character limit. If the 2000 character limit is exceeded, the webhook will fail to post.

This change shortens the checkInResult by only taking the first sentence.

Before this change, my webhook content is over 2000 characters as I am checking in on 7 different accounts.
Only making this change for english as the chinese did not have as many characters.